### PR TITLE
Make the description edit mode more obvious

### DIFF
--- a/src/views/project.js
+++ b/src/views/project.js
@@ -447,6 +447,7 @@ my.ReadmeView = Backbone.View.extend({
     this.$el.find(".readme").hide();
 
     var options = {
+      lineNumbers: true,
       lineWrapping: true,
       theme : "default",
       mode : "markdown",


### PR DESCRIPTION
Particularly when the description is currently blank, it’s not obvious what’s happening after the edit button is clicked. I’ve added line numbers to make it a bit clearer.
