### PR TITLE
Make the link to example a relative url

### DIFF
--- a/index.html
+++ b/index.html
@@ -100,7 +100,7 @@
         </div>
         <h2 class="followup">And all of this from within your browser &mdash; nothing to install, no backend to worry about !</h2>
         <p class="actions">
-          <a class="btn btn-primary btn-large" href="http://explorer.okfnlabs.org/#rgrp/e3e0b0f18dfe151f9f7e">
+          <a class="btn btn-primary btn-large" href="#rgrp/e3e0b0f18dfe151f9f7e">
             Check out an example<br />(house prices) &raquo;
           </a>
           &mdash;


### PR DESCRIPTION
When running locally, I kept being transported to explorer.okfnlabs.org without realising why! This link was the culprit.
